### PR TITLE
feat: Match deletion and stat updating.

### DIFF
--- a/backend/src/main/java/Matchmaking/CourtAssigners/Court.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/Court.java
@@ -1,10 +1,16 @@
 package Matchmaking.CourtAssigners;
 
 import Matchmaking.Match;
+import Matchmaking.Outcome;
 import Matchmaking.Player;
+import java.io.IOException;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Set;
+import server.exceptions.NoItemFoundException;
+import server.exceptions.NoItemMadeException;
 
 /**
  * Representation of a court containing players. Encapsulates match data with other data like
@@ -13,16 +19,22 @@ import java.util.NoSuchElementException;
 public class Court implements ICourt{
 
   private Match match;
-  private List<Player> players;
+  private final List<Player> players;
+  private final Set<Player> leavingPlayers;
+  private int outcome;
 
   public Court(){
     this.match = null;
-    players = new LinkedList<>();
+    this.players = new LinkedList<>();
+    this.leavingPlayers = new HashSet<>();
+    outcome = 0;
   }
 
   public Court(Match match, List<Player> players){
     this.match = match;
     this.players = players;
+    this.leavingPlayers = new HashSet<>();
+    outcome = 0;
   }
 
   /**
@@ -42,13 +54,15 @@ public class Court implements ICourt{
    */
   @Override
   public void addPlayer(Player player) throws IllegalStateException {
-    if(this.match == null){
+    if(this.match != null){
       throw new IllegalStateException("Match is currently going on, cannot currently "
           + "add more players");
     }else {
       this.players.add(player);
     }
   }
+
+
 
   /**
    * @return the current match that is going on.
@@ -65,5 +79,75 @@ public class Court implements ICourt{
   @Override
   public void setMatch(Match newMatch) {
     this.match = newMatch;
+  }
+
+  /**
+   * Takes a player and uses their data to vote to end the game.
+   *
+   * @param player The player voting to end the game
+   * @param playerWon Whether the player won that particular game. Can be "win", "tie", or "loss".
+   * @return Whether their vote was enough to end the game.
+   */
+  @Override
+  public boolean tryEndGame(Player player, String playerWon) throws Exception {
+    // If the player is leaving for the first time, Add their win/loss to the running tally
+    if(this.leavingPlayers.add(player)){
+    // find out which team that player is on.
+    boolean t1 = false;
+    boolean t2 = false;
+    try{
+      match.getTeam1().getPlayer(player.getId());
+      t1 = true;
+    }catch(IOException ignored){}
+
+    try{
+      match.getTeam2().getPlayer(player.getId());
+      t2 = true;
+    }catch(IOException ignored){}
+
+    if(!t1 && !t2){
+      throw new NoItemFoundException("Player is not in match");
+    }else if(t1 && t2){
+      throw new Exception("Player found on both teams");
+    }
+
+      // Once we know what team the person is on, whether they won or lost can be
+      // added to the running total
+    if(!playerWon.equalsIgnoreCase("tie")){
+      if(t1){
+        if(playerWon.equalsIgnoreCase("win")){
+          this.outcome++;
+        }else{
+          this.outcome--;
+        }
+      }
+      if(t2){
+        if(playerWon.equals("win")){
+          this.outcome--;
+        }else{
+          this.outcome++;
+        }
+      }
+    }
+    }
+
+    // if all the players have left, return true so that the decommission of this
+    // match object can begin
+
+    if(this.leavingPlayers.size() == this.players.size()){
+
+      if(this.outcome > 0){
+        this.match.setOutcome(Outcome.TEAM1WIN);
+      }else if(this.outcome < 0){
+        this.match.setOutcome(Outcome.TEAM2WIN);
+      }else{
+        this.match.setOutcome(Outcome.TIE);
+      }
+
+      return true;
+    }else{
+      return false;
+    }
+
   }
 }

--- a/backend/src/main/java/Matchmaking/CourtAssigners/Court.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/Court.java
@@ -10,27 +10,26 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 import server.exceptions.NoItemFoundException;
-import server.exceptions.NoItemMadeException;
 
 /**
- * Representation of a court containing players. Encapsulates match data with other data like
- * more raw access to the players.
+ * Representation of a court containing players. Encapsulates match data with other data like more
+ * raw access to the players.
  */
-public class Court implements ICourt{
+public class Court implements ICourt {
 
   private Match match;
   private final List<Player> players;
   private final Set<Player> leavingPlayers;
   private int outcome;
 
-  public Court(){
+  public Court() {
     this.match = null;
     this.players = new LinkedList<>();
     this.leavingPlayers = new HashSet<>();
     outcome = 0;
   }
 
-  public Court(Match match, List<Player> players){
+  public Court(Match match, List<Player> players) {
     this.match = match;
     this.players = players;
     this.leavingPlayers = new HashSet<>();
@@ -54,15 +53,13 @@ public class Court implements ICourt{
    */
   @Override
   public void addPlayer(Player player) throws IllegalStateException {
-    if(this.match != null){
-      throw new IllegalStateException("Match is currently going on, cannot currently "
-          + "add more players");
-    }else {
+    if (this.match != null) {
+      throw new IllegalStateException(
+          "Match is currently going on, cannot currently " + "add more players");
+    } else {
       this.players.add(player);
     }
   }
-
-
 
   /**
    * @return the current match that is going on.
@@ -73,9 +70,7 @@ public class Court implements ICourt{
     return this.match;
   }
 
-  /**
-   * Sets the match to a new value.
-   */
+  /** Sets the match to a new value. */
   @Override
   public void setMatch(Match newMatch) {
     this.match = newMatch;
@@ -91,63 +86,64 @@ public class Court implements ICourt{
   @Override
   public boolean tryEndGame(Player player, String playerWon) throws Exception {
     // If the player is leaving for the first time, Add their win/loss to the running tally
-    if(this.leavingPlayers.add(player)){
-    // find out which team that player is on.
-    boolean t1 = false;
-    boolean t2 = false;
-    try{
-      match.getTeam1().getPlayer(player.getId());
-      t1 = true;
-    }catch(IOException ignored){}
+    if (this.leavingPlayers.add(player)) {
+      // find out which team that player is on.
+      boolean t1 = false;
+      boolean t2 = false;
+      try {
+        match.getTeam1().getPlayer(player.getId());
+        t1 = true;
+      } catch (IOException ignored) {
+      }
 
-    try{
-      match.getTeam2().getPlayer(player.getId());
-      t2 = true;
-    }catch(IOException ignored){}
+      try {
+        match.getTeam2().getPlayer(player.getId());
+        t2 = true;
+      } catch (IOException ignored) {
+      }
 
-    if(!t1 && !t2){
-      throw new NoItemFoundException("Player is not in match");
-    }else if(t1 && t2){
-      throw new Exception("Player found on both teams");
-    }
+      if (!t1 && !t2) {
+        throw new NoItemFoundException("Player is not in match");
+      } else if (t1 && t2) {
+        throw new Exception("Player found on both teams");
+      }
 
       // Once we know what team the person is on, whether they won or lost can be
       // added to the running total
-    if(!playerWon.equalsIgnoreCase("tie")){
-      if(t1){
-        if(playerWon.equalsIgnoreCase("win")){
-          this.outcome++;
-        }else{
-          this.outcome--;
+      if (!playerWon.equalsIgnoreCase("tie")) {
+        if (t1) {
+          if (playerWon.equalsIgnoreCase("win")) {
+            this.outcome++;
+          } else {
+            this.outcome--;
+          }
+        }
+        if (t2) {
+          if (playerWon.equals("win")) {
+            this.outcome--;
+          } else {
+            this.outcome++;
+          }
         }
       }
-      if(t2){
-        if(playerWon.equals("win")){
-          this.outcome--;
-        }else{
-          this.outcome++;
-        }
-      }
-    }
     }
 
     // if all the players have left, return true so that the decommission of this
     // match object can begin
 
-    if(this.leavingPlayers.size() == this.players.size()){
+    if (this.leavingPlayers.size() == this.players.size()) {
 
-      if(this.outcome > 0){
+      if (this.outcome > 0) {
         this.match.setOutcome(Outcome.TEAM1WIN);
-      }else if(this.outcome < 0){
+      } else if (this.outcome < 0) {
         this.match.setOutcome(Outcome.TEAM2WIN);
-      }else{
+      } else {
         this.match.setOutcome(Outcome.TIE);
       }
 
       return true;
-    }else{
+    } else {
       return false;
     }
-
   }
 }

--- a/backend/src/main/java/Matchmaking/CourtAssigners/CourtAssigner.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/CourtAssigner.java
@@ -5,8 +5,10 @@ import Matchmaking.MatchAlgs.IMatchMaker;
 import Matchmaking.Player;
 import Matchmaking.SkillCalculators.SkillUpdater;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import server.exceptions.NoItemMadeException;
 
@@ -73,6 +75,28 @@ public class CourtAssigner implements ICourtAssigner{
   }
 
   /**
+   * Takes in an index and overwrites the court at that location, before updating the players based
+   * on how that match went.
+   * @param index the index of the court to be overwritten
+   * @return The list of newly updated players
+   */
+  @Override
+  public Map<String,Player> removeInternalCourt(int index) {
+    // Update all the players before adding them into the system.
+    try{
+      Match match = this.courts[index].getMatch();
+      this.skillUpdater.skillUpdater(match);
+    }catch(Exception ignored){}
+
+    Map<String,Player> playerMap = new HashMap<>();
+    for(Player i: this.courts[index].getPlayers()){
+      playerMap.put(i.getId(),i);
+    }
+    this.courts[index] = new Court();
+    return playerMap;
+  }
+
+  /**
    * Takes in a court and adds it into the list of courts
    * @param court The court to be added
    * @return The index in the array where the court was added. -1 if addition was unsuccessful.
@@ -89,4 +113,6 @@ public class CourtAssigner implements ICourtAssigner{
     }
     return courtAddedIndex;
   }
+
+
 }

--- a/backend/src/main/java/Matchmaking/CourtAssigners/CourtAssigner.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/CourtAssigner.java
@@ -6,13 +6,12 @@ import Matchmaking.Player;
 import Matchmaking.SkillCalculators.SkillUpdater;
 import java.io.IOException;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import server.exceptions.NoItemMadeException;
 
-public class CourtAssigner implements ICourtAssigner{
+public class CourtAssigner implements ICourtAssigner {
 
   // Using an array here to minimize chances of swapping things around.
   private final ICourt[] courts;
@@ -22,13 +21,14 @@ public class CourtAssigner implements ICourtAssigner{
 
   /**
    * Constructs a CourtAssigner object for managing an arbitrary number of courts.
+   *
    * @param numCourts The total number of courts that the assigner will be managing
    * @param matchMaker The matchmaker used across all courts
    * @param skillUpdater The skill updater used across all courts
    */
-  public CourtAssigner(int numCourts, IMatchMaker matchMaker, SkillUpdater skillUpdater){
+  public CourtAssigner(int numCourts, IMatchMaker matchMaker, SkillUpdater skillUpdater) {
     courts = new ICourt[numCourts];
-    for(int i = 0; i < numCourts; i++){
+    for (int i = 0; i < numCourts; i++) {
       courts[i] = new Court();
     }
     this.matchMaker = matchMaker;
@@ -45,20 +45,20 @@ public class CourtAssigner implements ICourtAssigner{
   @Override
   public int addPlayers(Queue<Player> newPlayers) throws NoItemMadeException, IOException {
     List<Player> queuePlayers = List.of(newPlayers.toArray(new Player[0]));
-    if (queuePlayers.size() < 10){
+    if (queuePlayers.size() < 10) {
       throw new NoItemMadeException("Queue length is not yet long enough for matchmaking.");
-    }else{
-      List<Match> matches = this.matchMaker.matchmaker(queuePlayers.subList(0,10), 2);
-      if (matches.size() == 1){
-        Court court = new Court(matches.get(0),queuePlayers.subList(0,10));
+    } else {
+      List<Match> matches = this.matchMaker.matchmaker(queuePlayers.subList(0, 10), 2);
+      if (matches.size() == 1) {
+        Court court = new Court(matches.get(0), queuePlayers.subList(0, 10));
         int courtMade = this.addInternalCourt(court);
-        if(courtMade >= 0){
+        if (courtMade >= 0) {
           return courtMade;
-        }else{
+        } else {
           throw new NoItemMadeException(
               "All Courts are full. Please wait for other players to finish");
         }
-      }else{
+      } else {
         throw new NoItemMadeException("Matchmaker made more matches than expected.");
       }
     }
@@ -77,20 +77,22 @@ public class CourtAssigner implements ICourtAssigner{
   /**
    * Takes in an index and overwrites the court at that location, before updating the players based
    * on how that match went.
+   *
    * @param index the index of the court to be overwritten
    * @return The list of newly updated players
    */
   @Override
-  public Map<String,Player> removeInternalCourt(int index) {
+  public Map<String, Player> removeInternalCourt(int index) {
     // Update all the players before adding them into the system.
-    try{
+    try {
       Match match = this.courts[index].getMatch();
       this.skillUpdater.skillUpdater(match);
-    }catch(Exception ignored){}
+    } catch (Exception ignored) {
+    }
 
-    Map<String,Player> playerMap = new HashMap<>();
-    for(Player i: this.courts[index].getPlayers()){
-      playerMap.put(i.getId(),i);
+    Map<String, Player> playerMap = new HashMap<>();
+    for (Player i : this.courts[index].getPlayers()) {
+      playerMap.put(i.getId(), i);
     }
     this.courts[index] = new Court();
     return playerMap;
@@ -98,13 +100,14 @@ public class CourtAssigner implements ICourtAssigner{
 
   /**
    * Takes in a court and adds it into the list of courts
+   *
    * @param court The court to be added
    * @return The index in the array where the court was added. -1 if addition was unsuccessful.
    */
-  private int addInternalCourt(Court court){
+  private int addInternalCourt(Court court) {
     int courtAddedIndex = -1;
-    for(int i = 0; i < this.courtsFilled.length; i++){
-      if(!this.courtsFilled[i]){
+    for (int i = 0; i < this.courtsFilled.length; i++) {
+      if (!this.courtsFilled[i]) {
         this.courts[i] = court;
         courtAddedIndex = i;
         this.courtsFilled[i] = true;
@@ -113,6 +116,4 @@ public class CourtAssigner implements ICourtAssigner{
     }
     return courtAddedIndex;
   }
-
-
 }

--- a/backend/src/main/java/Matchmaking/CourtAssigners/ICourt.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/ICourt.java
@@ -1,41 +1,37 @@
 package Matchmaking.CourtAssigners;
 
 import Matchmaking.Match;
-import Matchmaking.Outcome;
 import Matchmaking.Player;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
-import server.exceptions.NoItemFoundException;
 
 /**
- * Representation of a court containing players. Encapsulates match data with other data like
- * more raw access to the players.
+ * Representation of a court containing players. Encapsulates match data with other data like more
+ * raw access to the players.
  */
 public interface ICourt {
 
   /**
    * Gets the list of players currently assigned to the court.
+   *
    * @return The list of players
    */
   public List<Player> getPlayers();
 
   /**
    * Adds a player to the court when a match is not currently running.
+   *
    * @param player A player object representing someone's account
    */
   public void addPlayer(Player player) throws IllegalStateException;
 
   /**
-   *
    * @return the current match that is going on.
    * @throws NoSuchElementException Thrown when the match hasn't been created yet
    */
   public Match getMatch() throws NoSuchElementException;
 
-  /**
-   * Sets the match to a new value.
-   */
+  /** Sets the match to a new value. */
   public void setMatch(Match newMatch);
 
   /**

--- a/backend/src/main/java/Matchmaking/CourtAssigners/ICourt.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/ICourt.java
@@ -36,4 +36,6 @@ public interface ICourt {
    */
   public void setMatch(Match newMatch);
 
+  public boolean endGame()
+
 }

--- a/backend/src/main/java/Matchmaking/CourtAssigners/ICourt.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/ICourt.java
@@ -1,10 +1,12 @@
 package Matchmaking.CourtAssigners;
 
 import Matchmaking.Match;
+import Matchmaking.Outcome;
 import Matchmaking.Player;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import server.exceptions.NoItemFoundException;
 
 /**
  * Representation of a court containing players. Encapsulates match data with other data like
@@ -36,6 +38,12 @@ public interface ICourt {
    */
   public void setMatch(Match newMatch);
 
-  public boolean endGame()
-
+  /**
+   * Takes a player and uses their data to vote to end the game.
+   *
+   * @param player The player voting to end the game
+   * @param playerWon Whether the player won that particular game. Can be "win", "tie", or "loss".
+   * @return Whether their vote was enough to end the game.
+   */
+  boolean tryEndGame(Player player, String playerWon) throws Exception;
 }

--- a/backend/src/main/java/Matchmaking/CourtAssigners/ICourtAssigner.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/ICourtAssigner.java
@@ -5,6 +5,7 @@ import Matchmaking.Player;
 import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Queue;
 import server.exceptions.NoItemMadeException;
 
@@ -28,6 +29,11 @@ public interface ICourtAssigner {
    */
   public ICourt[] getCourts();
 
+  /**
+   *
+   * @param index
+   */
+  public Map<String,Player> removeInternalCourt(int index);
 
 
 

--- a/backend/src/main/java/Matchmaking/CourtAssigners/ICourtAssigner.java
+++ b/backend/src/main/java/Matchmaking/CourtAssigners/ICourtAssigner.java
@@ -1,23 +1,21 @@
 package Matchmaking.CourtAssigners;
 
-import Matchmaking.Match;
 import Matchmaking.Player;
 import java.io.IOException;
-import java.util.LinkedList;
-import java.util.List;
 import java.util.Map;
 import java.util.Queue;
 import server.exceptions.NoItemMadeException;
 
 /**
- * Court Assigner interface for managing an arbitrary number of courts, and assigning people to
- * the best fitting court.
+ * Court Assigner interface for managing an arbitrary number of courts, and assigning people to the
+ * best fitting court.
  */
 public interface ICourtAssigner {
 
   /**
    * Takes in a new player and uses its positioning and skill level to add it to the most fitting
    * team.
+   *
    * @param newPlayers The new player being added to a match ahead of time.
    * @return The index of the court containing the added player.
    */
@@ -25,16 +23,13 @@ public interface ICourtAssigner {
 
   /**
    * Returns the array of courts in the assigner
+   *
    * @return the array of courts in the assigner
    */
   public ICourt[] getCourts();
 
   /**
-   *
    * @param index
    */
-  public Map<String,Player> removeInternalCourt(int index);
-
-
-
+  public Map<String, Player> removeInternalCourt(int index);
 }

--- a/backend/src/main/java/Matchmaking/Player.java
+++ b/backend/src/main/java/Matchmaking/Player.java
@@ -46,7 +46,7 @@ public class Player implements IPlayer {
       // get next int from 0 (inclusive) to length - 1 (exclusive)
 
       int nextCharInt = random.nextInt(initialChars.length() - 2);
-      idBuilder.append(initialChars, nextCharInt , nextCharInt + 1);
+      idBuilder.append(initialChars, nextCharInt, nextCharInt + 1);
 
       length++;
     }

--- a/backend/src/main/java/Matchmaking/SkillCalculators/EloSkill.java
+++ b/backend/src/main/java/Matchmaking/SkillCalculators/EloSkill.java
@@ -19,20 +19,20 @@ public class EloSkill implements SkillUpdater {
   public void skillUpdater(Match match) throws IOException {
 
     Outcome outcome = match.getOutcome();
-    if(outcome == Outcome.ONGOING){
+    if (outcome == Outcome.ONGOING) {
       throw new IOException("Cannot Update Skills, Match is Incomplete.");
     }
-    if(outcome == Outcome.TIE) {
+    if (outcome == Outcome.TIE) {
       return;
     }
-    if(outcome == Outcome.TEAM1WIN){
+    if (outcome == Outcome.TEAM1WIN) {
       Team team1 = match.getTeam1();
       Team team2 = match.getTeam2();
       this.EloHelper(team1, team2);
       return;
     }
 
-    if(outcome == Outcome.TEAM2WIN){
+    if (outcome == Outcome.TEAM2WIN) {
       Team team1 = match.getTeam1();
       Team team2 = match.getTeam2();
       this.EloHelper(team2, team1);
@@ -45,10 +45,10 @@ public class EloSkill implements SkillUpdater {
     float wOldRank = wTeam.getAvgSkill();
     float lOldRank = lTeam.getAvgSkill();
 
-    double wExpected = 1/(1+ Math.pow(10, (lOldRank - wOldRank) / 400.0));
-    double lExpected = 1/(1+ Math.pow(10, (wOldRank - lOldRank) / 400.0));
-    double wNewRank = wOldRank + (30 *(1 - wExpected));
-    double lNewRank = lOldRank + (30*(0 - lExpected));
+    double wExpected = 1 / (1 + Math.pow(10, (lOldRank - wOldRank) / 400.0));
+    double lExpected = 1 / (1 + Math.pow(10, (wOldRank - lOldRank) / 400.0));
+    double wNewRank = wOldRank + (30 * (1 - wExpected));
+    double lNewRank = lOldRank + (30 * (0 - lExpected));
     float wAdd = (float) wNewRank - wOldRank;
     float lSubtract = lOldRank - (float) lNewRank;
     for (Player player : wTeam.getPlayers()) {
@@ -56,7 +56,7 @@ public class EloSkill implements SkillUpdater {
       player.setSkillLevel(oldSkill + wAdd);
     }
 
-    for (Player player: lTeam.getPlayers()){
+    for (Player player : lTeam.getPlayers()) {
       float oldSkill = player.getSkillLevel();
       player.setSkillLevel(oldSkill - lSubtract);
     }

--- a/backend/src/main/java/Matchmaking/SkillCalculators/SimpleSkill.java
+++ b/backend/src/main/java/Matchmaking/SkillCalculators/SimpleSkill.java
@@ -18,13 +18,13 @@ public class SimpleSkill implements SkillUpdater {
   public void skillUpdater(Match match) throws IOException {
 
     Outcome outcome = match.getOutcome();
-    if(outcome == Outcome.ONGOING){
+    if (outcome == Outcome.ONGOING) {
       throw new IOException("Cannot Update Skills, Match is Incomplete.");
     }
-    if(outcome == Outcome.TIE){
+    if (outcome == Outcome.TIE) {
       return;
     }
-    if(outcome == Outcome.TEAM1WIN){
+    if (outcome == Outcome.TEAM1WIN) {
       List<Player> team1Players = match.getTeam1().getPlayers();
       List<Player> team2Players = match.getTeam2().getPlayers();
       for (Player player : team1Players) {
@@ -40,7 +40,7 @@ public class SimpleSkill implements SkillUpdater {
       return;
     }
 
-    if(outcome == Outcome.TEAM2WIN){
+    if (outcome == Outcome.TEAM2WIN) {
       List<Player> team1Players = match.getTeam1().getPlayers();
       List<Player> team2Players = match.getTeam2().getPlayers();
       for (Player player : team2Players) {
@@ -56,6 +56,5 @@ public class SimpleSkill implements SkillUpdater {
     }
 
     throw new IOException("Matchmaking.Outcome is Unexpected Number");
-
   }
 }

--- a/backend/src/main/java/Matchmaking/SkillCalculators/WLSkill.java
+++ b/backend/src/main/java/Matchmaking/SkillCalculators/WLSkill.java
@@ -18,20 +18,20 @@ public class WLSkill implements SkillUpdater {
   public void skillUpdater(Match match) throws IOException {
 
     Outcome outcome = match.getOutcome();
-    if(outcome == Outcome.ONGOING){
+    if (outcome == Outcome.ONGOING) {
       throw new IOException("Cannot Update Skills, Match is Incomplete.");
     }
-    if(outcome == Outcome.TIE){
+    if (outcome == Outcome.TIE) {
       return;
     }
-    if (outcome == Outcome.TEAM1WIN){
+    if (outcome == Outcome.TEAM1WIN) {
       List<Player> team1Players = match.getTeam1().getPlayers();
       List<Player> team2Players = match.getTeam2().getPlayers();
       WLHelper(team1Players, team2Players);
       return;
     }
 
-    if (outcome == Outcome.TEAM2WIN){
+    if (outcome == Outcome.TEAM2WIN) {
       List<Player> team1Players = match.getTeam1().getPlayers();
       List<Player> team2Players = match.getTeam2().getPlayers();
       WLHelper(team2Players, team1Players);

--- a/backend/src/main/java/Matchmaking/Team.java
+++ b/backend/src/main/java/Matchmaking/Team.java
@@ -1,12 +1,9 @@
 package Matchmaking;
 
-
-import Matchmaking.Player;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import org.eclipse.jetty.util.IO;
 
 public class Team {
   private List<Player> players;
@@ -31,6 +28,7 @@ public class Team {
 
   /**
    * May want to make a new exception for this, IO Exception isn't the best
+   *
    * @param id
    * @return
    * @throws IOException
@@ -43,6 +41,7 @@ public class Team {
     }
     throw new IOException("Player Not Found");
   }
+
   public boolean isPlayer(String id) {
     for (Player player : this.players) {
       if (Objects.equals(player.getId(), id)) {
@@ -51,6 +50,7 @@ public class Team {
     }
     return false;
   }
+
   public int getSize() {
     return this.size;
   }

--- a/backend/src/main/java/datastorage/DataStore.java
+++ b/backend/src/main/java/datastorage/DataStore.java
@@ -44,8 +44,8 @@ public interface DataStore {
    * @param id A string containing the ID of the particular player we're referencing. Used primarily
    *     for internal purposes.
    * @return The player that was just deleted. Null if there was no deleted player.
-   * @throws NoItemFoundException In case no player has been deleted, throw an exception to notify
-   *    * the caller of this
+   * @throws NoItemFoundException In case no player has been deleted, throw an exception to notify *
+   *     the caller of this
    */
   public Player deleteItem(String id) throws NoItemFoundException;
 
@@ -65,12 +65,14 @@ public interface DataStore {
 
   /**
    * Method that adds a player to the Queue
+   *
    * @param ID, player to be added to the queue
    */
   public Player addQueue(String ID) throws NoItemFoundException;
 
   /**
    * Returns the queue for getting player data
+   *
    * @return The queue representing the current matchmaking queue
    */
   public Queue<Player> getQueue();

--- a/backend/src/main/java/datastorage/SimpleDataStore.java
+++ b/backend/src/main/java/datastorage/SimpleDataStore.java
@@ -17,7 +17,8 @@ public class SimpleDataStore implements DataStore {
 
   private HashMap<String, Player> dataMap;
   private Queue<Player> playerQueue;
-  public SimpleDataStore(){
+
+  public SimpleDataStore() {
     this.dataMap = new HashMap<>();
     this.playerQueue = new LinkedList<>();
   }
@@ -52,8 +53,9 @@ public class SimpleDataStore implements DataStore {
       // ID is already in database, we can't be reasonably sure that this player already
       // exists within the database, or that two IDs are the same, so we change the ID of one of the
       // players and recurse.
-      throw new ItemAlreadyExistsException("Player to be added already exists within database. "
-          + "Please use updatePlayer in this instance.");
+      throw new ItemAlreadyExistsException(
+          "Player to be added already exists within database. "
+              + "Please use updatePlayer in this instance.");
     } else {
       dataMap.put(player.getId(), player);
     }
@@ -72,6 +74,7 @@ public class SimpleDataStore implements DataStore {
     if (!dataMap.containsKey(id)) {
       throw new NoItemFoundException("No player to update. Please use addPlayer in this instance.");
     } else {
+      player.setId(id);
       dataMap.put(id, player);
     }
   }
@@ -83,17 +86,17 @@ public class SimpleDataStore implements DataStore {
    *     for internal purposes.
    * @return The player that was just deleted.
    * @throws NoItemFoundException In case no player has been deleted, throw an exception to notify
-   * the caller of this
+   *     the caller of this
    */
   @Override
-  public Player deleteItem(String id) throws NoItemFoundException{
+  public Player deleteItem(String id) throws NoItemFoundException {
     if (dataMap.containsKey(id)) {
       // While I am aware that the standard HashMap returns null in these situations, it isn't
       // guaranteed. As of such I am adding a little bit of extra logic here.
       Player deletedPlayer = dataMap.get(id);
       dataMap.remove(id);
       return deletedPlayer;
-    }else{
+    } else {
       throw new NoItemFoundException("No item found within the database to delete.");
     }
   }
@@ -118,6 +121,7 @@ public class SimpleDataStore implements DataStore {
 
   /**
    * Method that adds a player to the queue
+   *
    * @param ID, player to be added to the queue
    */
   public Player addQueue(String ID) throws NoItemFoundException {
@@ -140,4 +144,3 @@ public class SimpleDataStore implements DataStore {
     return this.playerQueue;
   }
 }
-

--- a/backend/src/main/java/server/Server.java
+++ b/backend/src/main/java/server/Server.java
@@ -6,6 +6,7 @@ import Matchmaking.MatchAlgs.SimpleMatchMaker;
 import Matchmaking.SkillCalculators.SimpleSkill;
 import datastorage.DataStore;
 import datastorage.SimpleDataStore;
+import server.handlers.match.MatchEndHandler;
 import server.handlers.match.MatchViewHandler;
 import server.handlers.profile.ProfileAddHandler;
 import server.handlers.profile.ProfileEditHandler;
@@ -41,6 +42,7 @@ public class Server {
     Spark.get("profile-add", new ProfileAddHandler(this));
     Spark.get("profile-edit", new ProfileEditHandler(this));
     Spark.get("profile-view", new ProfileViewHandler(this));
+    Spark.get("match-end", new MatchEndHandler(this));
     Spark.get("match-view", new MatchViewHandler(this));
     Spark.get("queue-add", new QueueAddHandler(this));
     Spark.get("queue-view", new QueueViewHandler(this));
@@ -54,7 +56,7 @@ public class Server {
     System.out.println("For Profile Viewing:  http://localhost:" + port + "/profile-view");
     System.out.println("For Profile Adding:   http://localhost:" + port + "/profile-add");
     System.out.println("For Profile Editing:  http://localhost:" + port + "/profile-edit");
-    System.out.println("For Match Editing:    http://localhost:" + port + "/match-edit");
+    System.out.println("For Match Ending:     http://localhost:" + port + "/match-end");
     System.out.println("For Match Viewing:    http://localhost:" + port + "/match-view");
     System.out.println("For Queue Viewing:    http://localhost:" + port + "/queue-view");
     System.out.println("For Queue Adding:     http://localhost:" + port + "/queue-add");

--- a/backend/src/main/java/server/Server.java
+++ b/backend/src/main/java/server/Server.java
@@ -1,5 +1,7 @@
 package server;
 
+import static spark.Spark.after;
+
 import Matchmaking.CourtAssigners.CourtAssigner;
 import Matchmaking.CourtAssigners.ICourtAssigner;
 import Matchmaking.MatchAlgs.SimpleMatchMaker;
@@ -14,8 +16,6 @@ import server.handlers.profile.ProfileViewHandler;
 import server.handlers.queue.QueueAddHandler;
 import server.handlers.queue.QueueViewHandler;
 import spark.Spark;
-
-import static spark.Spark.after;
 
 public class Server {
   static final int port = 3232;
@@ -33,10 +33,11 @@ public class Server {
 
     Spark.port(port);
 
-    after((request, response) -> {
-      response.header("Access-Control-Allow-Origin", "*");
-      response.header("Access-Control-Allow-Methods", "*");
-    });
+    after(
+        (request, response) -> {
+          response.header("Access-Control-Allow-Origin", "*");
+          response.header("Access-Control-Allow-Methods", "*");
+        });
 
     // Set up handlers:
     Spark.get("profile-add", new ProfileAddHandler(this));
@@ -81,13 +82,14 @@ public class Server {
   }
 
   /**
-   * Main method. Run to initialize server. Instantiates the server with a mocked data store,
-   * court assigner, matchmaker, and skill assigner.
+   * Main method. Run to initialize server. Instantiates the server with a mocked data store, court
+   * assigner, matchmaker, and skill assigner.
+   *
    * @param args
    */
   public static void main(String[] args) {
-    Server server = new Server(
-        new SimpleDataStore(),
-        new CourtAssigner(6,new SimpleMatchMaker(), new SimpleSkill()));
+    Server server =
+        new Server(
+            new SimpleDataStore(), new CourtAssigner(6, new SimpleMatchMaker(), new SimpleSkill()));
   }
 }

--- a/backend/src/main/java/server/exceptions/NoItemMadeException.java
+++ b/backend/src/main/java/server/exceptions/NoItemMadeException.java
@@ -1,6 +1,6 @@
 package server.exceptions;
 
-public class NoItemMadeException extends Exception{
+public class NoItemMadeException extends Exception {
   public NoItemMadeException(String message) {
     super(message);
   }

--- a/backend/src/main/java/server/handlers/match/MatchEndHandler.java
+++ b/backend/src/main/java/server/handlers/match/MatchEndHandler.java
@@ -13,13 +13,13 @@ import spark.Response;
 import spark.Route;
 
 /** Adds a player to the most fitting match for their skill levels */
-public class MatchAddHandler implements Route {
+public class MatchEndHandler implements Route {
   private Server server;
 
   /**
    * @param server
    */
-  public MatchAddHandler(Server server) {
+  public MatchEndHandler(Server server) {
     this.server = server;
   }
 
@@ -31,27 +31,35 @@ public class MatchAddHandler implements Route {
     JsonAdapter<Map<String, Object>> adapter = moshi.adapter(mapStringObject);
     HashMap<String, Object> responseMap = new HashMap<>();
 
-    String playerName;
-    Match match;
+    // Get the player ID and if they won
+    String playerID;
+    boolean playerWon;
     try {
-      playerName = request.queryMap().get("name").value();
-      match = null;
-      // TODO: figure out how to match a specific player with a specific team, then use matchmaker
-      // to assign player.
-
+      playerID = request.queryMap().get("id").value();
     } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
       responseMap.put(
           "details",
-          "action keyword must contain the word 'edit' or 'delete'. Any"
-              + "other word will result in an error");
+          "Error in specifying 'id' variable: ");
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }
+    try {
+      playerWon = Boolean.parseBoolean(request.queryMap().get("playerWon").value());
+    } catch (Exception e) {
+      responseMap.put("result", "error_bad_request");
+      responseMap.put(
+          "details",
+          "Error in specifying 'playerWon' variable. Variable must be true or false");
+      responseMap.put("queries", request.queryParams());
+      return adapter.toJson(responseMap);
+    }
+
+
+
     // Success. Return success message
     responseMap.put("result", "success");
     responseMap.put("queries", request.queryParams());
-    responseMap.put("matchAdded", match);
     return adapter.toJson(responseMap);
   }
 }

--- a/backend/src/main/java/server/handlers/match/MatchEndHandler.java
+++ b/backend/src/main/java/server/handlers/match/MatchEndHandler.java
@@ -1,7 +1,6 @@
 package server.handlers.match;
 
 import Matchmaking.CourtAssigners.ICourt;
-import Matchmaking.Match;
 import Matchmaking.Player;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -42,18 +41,16 @@ public class MatchEndHandler implements Route {
       player = this.server.getDataStore().getPlayer(playerID);
     } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
-      responseMap.put(
-          "details",
-          "Error in specifying 'id' variable: ");
+      responseMap.put("details", "Error in specifying 'id' variable: ");
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }
     try {
       // If the playerWon value is correct, move onto the next step.
       playerWon = request.queryMap().get("playerWon").value();
-      if(!(playerWon.equalsIgnoreCase("win") ||
-          playerWon.equalsIgnoreCase("tie") ||
-          playerWon.equalsIgnoreCase("lose"))){
+      if (!(playerWon.equalsIgnoreCase("win")
+          || playerWon.equalsIgnoreCase("tie")
+          || playerWon.equalsIgnoreCase("lose"))) {
         throw new Exception();
       }
     } catch (Exception e) {
@@ -69,12 +66,12 @@ public class MatchEndHandler implements Route {
     // to the court's internal tally
     ICourt[] courts = this.server.getCourtAssigner().getCourts();
 
-    for(int i = 0; i < courts.length; i++){
-      if(courts[i].getPlayers().contains(player)){
-        if(courts[i].tryEndGame(player,playerWon)){
+    for (int i = 0; i < courts.length; i++) {
+      if (courts[i].getPlayers().contains(player)) {
+        if (courts[i].tryEndGame(player, playerWon)) {
           // This court has done its job and can now be removed.
           Map<String, Player> playerMap = server.getCourtAssigner().removeInternalCourt(i);
-          for(String pID: playerMap.keySet()){
+          for (String pID : playerMap.keySet()) {
             server.getDataStore().updatePlayer(pID, playerMap.get(pID));
           }
         }

--- a/backend/src/main/java/server/handlers/match/MatchViewHandler.java
+++ b/backend/src/main/java/server/handlers/match/MatchViewHandler.java
@@ -1,13 +1,11 @@
 package server.handlers.match;
 
 import Matchmaking.CourtAssigners.ICourt;
-import Matchmaking.IMatch;
 import Matchmaking.Match;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import java.lang.reflect.Type;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
@@ -47,20 +45,20 @@ public class MatchViewHandler implements Route {
       ICourt[] courts = server.getCourtAssigner().getCourts();
       LinkedList<Match> matches = new LinkedList<>();
 
-      for(ICourt i: courts){
+      for (ICourt i : courts) {
         Match match;
-        try{
+        try {
           match = i.getMatch();
           matches.add(match);
-        }catch(IllegalStateException ignored){}
+        } catch (IllegalStateException ignored) {
+        }
       }
       responseMap.put("matches", matches);
-
 
       // Success. Return success message
       responseMap.put("result", "success");
       responseMap.put("queries", request.queryParams());
-      //responseMap.put("matches", matches);
+      // responseMap.put("matches", matches);
       return adapter.toJson(responseMap);
     } catch (Exception e) {
       responseMap.put("result", "internal_server_error");

--- a/backend/src/main/java/server/handlers/profile/ProfileAddHandler.java
+++ b/backend/src/main/java/server/handlers/profile/ProfileAddHandler.java
@@ -44,46 +44,45 @@ public class ProfileAddHandler implements Route {
 
     // Run a check on each queryparam
 
-    // TODO: Run this in a for loop for brevity
-    try{
-      if(request.queryMap().hasKey("id")) {
+    try {
+      if (request.queryMap().hasKey("id")) {
         playerID = request.queryMap().get("id").value();
-      }else{
+      } else {
         throw new Exception("id neccesary");
       }
     } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
-      responseMap.put(
-          "details", "Error in specifying 'id' variable: " + e.getMessage());
+      responseMap.put("details", "Error in specifying 'id' variable: " + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }
-    try{
-      if(request.queryMap().hasKey("name")) {
+    try {
+      if (request.queryMap().hasKey("name")) {
         playerName = request.queryMap().get("name").value();
-      }else{
+      } else {
         throw new Exception("name neccesary");
       }
     } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
-      responseMap.put(
-          "details", "Error in specifying 'id' variable: " + e.getMessage());
+      responseMap.put("details", "Error in specifying 'id' variable: " + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }
-    try{
+    try {
 
-      if(request.queryMap().hasKey("position")) {
+      if (request.queryMap().hasKey("position")) {
         playerPosition = Position.valueOf(request.queryMap().get("position").value());
-      }else{
+      } else {
         throw new Exception("position query neccesary");
       }
     } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
       responseMap.put(
-          "details", "Error in specifying 'id' variable. Please use 'POINT_GUARD', "
+          "details",
+          "Error in specifying 'id' variable. Please use 'POINT_GUARD', "
               + "'SHOOTING_GUARD', 'SMALL_FORWARD', 'POWER_FORWARD', or 'CENTER' in your "
-              + "position query:  " + e.getMessage());
+              + "position query:  "
+              + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }

--- a/backend/src/main/java/server/handlers/profile/ProfileEditHandler.java
+++ b/backend/src/main/java/server/handlers/profile/ProfileEditHandler.java
@@ -40,105 +40,98 @@ public class ProfileEditHandler implements Route {
 
     // Get the id and action handlers, these are always necessary
 
-    try{
-      if(request.queryMap().hasKey("id")) {
+    try {
+      if (request.queryMap().hasKey("id")) {
         playerID = request.queryMap().get("id").value();
-      }else{
+      } else {
         throw new Exception("id neccesary");
       }
     } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
-      responseMap.put(
-          "details", "Error in specifying 'id' variable: " + e.getMessage());
+      responseMap.put("details", "Error in specifying 'id' variable: " + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }
-    try{
-      if(request.queryMap().hasKey("action")) {
+    try {
+      if (request.queryMap().hasKey("action")) {
         action = request.queryMap().get("action").value();
-        if(!(action.equalsIgnoreCase("edit") ||
-            action.equalsIgnoreCase("delete") )){
-          throw new Exception("Please use the string 'edit' or 'delete' when specifying "
-              + "action keyword");
+        if (!(action.equalsIgnoreCase("edit") || action.equalsIgnoreCase("delete"))) {
+          throw new Exception(
+              "Please use the string 'edit' or 'delete' when specifying " + "action keyword");
         }
-      }else{
+      } else {
         throw new Exception("action neccesary");
       }
     } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
-      responseMap.put(
-          "details", "Error in specifying 'action' variable: " + e.getMessage());
+      responseMap.put("details", "Error in specifying 'action' variable: " + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }
 
     // Now check the action:
 
-    if(action.equalsIgnoreCase("delete")){
-      try{
+    if (action.equalsIgnoreCase("delete")) {
+      try {
         server.getDataStore().deleteItem(playerID);
-      }catch(NoItemFoundException e){
+      } catch (NoItemFoundException e) {
         responseMap.put("result", "error_bad_request");
-        responseMap.put(
-            "details", "No item found to delete: " + e.getMessage());
+        responseMap.put("details", "No item found to delete: " + e.getMessage());
         responseMap.put("queries", request.queryParams());
         return adapter.toJson(responseMap);
-    }
-    }else if(action.equalsIgnoreCase("edit")){
+      }
+    } else if (action.equalsIgnoreCase("edit")) {
 
       // get the player ID and/or player Position, if they're not there, then just use the old value
 
       boolean playerNamePresent = false;
       boolean playerPositionPresent = false;
 
-
-      try{
+      try {
         player = server.getDataStore().getPlayer(playerID);
-      }catch(NoItemFoundException e){
+      } catch (NoItemFoundException e) {
         responseMap.put("result", "error_bad_request");
-        responseMap.put(
-            "details", "No item found to edit: " + e.getMessage());
+        responseMap.put("details", "No item found to edit: " + e.getMessage());
         responseMap.put("queries", request.queryParams());
         return adapter.toJson(responseMap);
       }
 
       // Check for player name
 
-      try{
-        if(request.queryMap().hasKey("name")) {
+      try {
+        if (request.queryMap().hasKey("name")) {
           playerName = request.queryMap().get("name").value();
           playerNamePresent = true;
-        }else{
+        } else {
           playerName = player.getName();
         }
       } catch (Exception e) {
         responseMap.put("result", "error_bad_request");
-        responseMap.put(
-            "details", "Error in specifying 'name' variable: " + e.getMessage());
+        responseMap.put("details", "Error in specifying 'name' variable: " + e.getMessage());
         responseMap.put("queries", request.queryParams());
         return adapter.toJson(responseMap);
       }
       // check for player position
-      try{
-        if(request.queryMap().hasKey("position")) {
+      try {
+        if (request.queryMap().hasKey("position")) {
           playerPosition = Position.valueOf(request.queryMap().get("position").value());
           playerPositionPresent = true;
-        }else{
+        } else {
           playerPosition = player.getPosition();
         }
       } catch (Exception e) {
         responseMap.put("result", "error_bad_request");
-        responseMap.put(
-            "details", "Error in specifying 'position' variable: " + e.getMessage());
+        responseMap.put("details", "Error in specifying 'position' variable: " + e.getMessage());
         responseMap.put("queries", request.queryParams());
         return adapter.toJson(responseMap);
       }
 
       // if neither is present, throw an error
-      if(!playerNamePresent && !playerPositionPresent){
+      if (!playerNamePresent && !playerPositionPresent) {
         responseMap.put("result", "error_bad_request");
         responseMap.put(
-            "details", "When editing, the player name or position must be present, "
+            "details",
+            "When editing, the player name or position must be present, "
                 + "otherwise there's nothing to edit");
         responseMap.put("queries", request.queryParams());
         return adapter.toJson(responseMap);
@@ -149,7 +142,7 @@ public class ProfileEditHandler implements Route {
       try {
         server.getDataStore().updatePlayer(playerID, player);
         System.out.println(server.getDataStore().getPlayers().toString());
-      }catch (NoItemFoundException e){
+      } catch (NoItemFoundException e) {
         responseMap.put("result", "error_datastore");
         responseMap.put(
             "details", "Internal datastore error when updating player: " + e.getMessage());
@@ -157,7 +150,7 @@ public class ProfileEditHandler implements Route {
         return adapter.toJson(responseMap);
       }
 
-    }else{
+    } else {
       responseMap.put("result", "error_bad_request");
       responseMap.put(
           "details",

--- a/backend/src/main/java/server/handlers/profile/ProfileViewHandler.java
+++ b/backend/src/main/java/server/handlers/profile/ProfileViewHandler.java
@@ -35,11 +35,11 @@ public class ProfileViewHandler implements Route {
     HashMap<String, Object> responseMap = new HashMap<>();
 
     String playerID;
-    try{
-      if(request.queryMap().hasKey("id")) {
+    try {
+      if (request.queryMap().hasKey("id")) {
         playerID = request.queryMap().get("id").value();
         responseMap.put("player", server.getDataStore().getPlayer(playerID));
-      }else{
+      } else {
         responseMap.put("players", server.getDataStore().getPlayers());
       }
     } catch (NoItemFoundException e) {

--- a/backend/src/main/java/server/handlers/queue/QueueAddHandler.java
+++ b/backend/src/main/java/server/handlers/queue/QueueAddHandler.java
@@ -1,25 +1,20 @@
 package server.handlers.queue;
 
-import Matchmaking.CourtAssigners.Court;
 import Matchmaking.CourtAssigners.ICourt;
 import Matchmaking.Player;
-import Matchmaking.Position;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import java.io.IOException;
 import java.lang.reflect.Type;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import server.Server;
-import server.exceptions.ItemAlreadyExistsException;
 import server.exceptions.NoItemFoundException;
 import server.exceptions.NoItemMadeException;
 import spark.Request;
 import spark.Response;
 import spark.Route;
-
 
 public class QueueAddHandler implements Route {
 
@@ -32,7 +27,7 @@ public class QueueAddHandler implements Route {
   /**
    * Invoked when a request is made on this route's corresponding path e.g. '/hello'
    *
-   * @param request  The request object providing information about the HTTP request
+   * @param request The request object providing information about the HTTP request
    * @param response The response object providing functionality for modifying the response
    * @return The content to be set in the response
    * @throws Exception implementation can choose to throw exception
@@ -49,8 +44,7 @@ public class QueueAddHandler implements Route {
       playerID = request.queryMap().get("id").value();
     } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
-      responseMap.put(
-          "details", "Error in specifying id variable: " + e.getMessage());
+      responseMap.put("details", "Error in specifying id variable: " + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }
@@ -58,22 +52,20 @@ public class QueueAddHandler implements Route {
     Player player;
     try {
       player = server.getDataStore().getPlayer(playerID);
-      if(!server.getDataStore().getQueue().contains(player)){
+      if (!server.getDataStore().getQueue().contains(player)) {
         player = this.server.getDataStore().addQueue(playerID);
-      }else{
+      } else {
         throw new Exception("Player has already been added to queue.");
       }
 
     } catch (NoItemFoundException e) {
       responseMap.put("result", "error_bad_request");
-      responseMap.put(
-          "details", "Player Not Found: " + e.getMessage());
+      responseMap.put("details", "Player Not Found: " + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
-    } catch (Exception e){
+    } catch (Exception e) {
       responseMap.put("result", "error_bad_request");
-      responseMap.put(
-          "details", e.getMessage());
+      responseMap.put("details", e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }
@@ -86,27 +78,24 @@ public class QueueAddHandler implements Route {
       court = server.getCourtAssigner().getCourts()[courtIndex];
       responseMap.put("court", court);
       responseMap.put("newCourtMade", true);
-      for(int i = 0; i < 10; i++){
+      for (int i = 0; i < 10; i++) {
         server.getDataStore().getQueue().poll();
       }
-    }catch(NoItemMadeException e){
-      if(!e.getMessage().equals("Queue length is not yet long enough for matchmaking.")){
+    } catch (NoItemMadeException e) {
+      if (!e.getMessage().equals("Queue length is not yet long enough for matchmaking.")) {
         responseMap.put("result", "matchmaking_error");
-        responseMap.put(
-            "details", "All queues full currently: " + e.getMessage());
+        responseMap.put("details", "All queues full currently: " + e.getMessage());
         responseMap.put("queries", request.queryParams());
         return adapter.toJson(responseMap);
       }
-    }catch(IOException e){
+    } catch (IOException e) {
       responseMap.put("result", "matchmaking_error");
-      responseMap.put(
-          "details", "Internal matchmaker error: " + e.getMessage());
+      responseMap.put("details", "Internal matchmaker error: " + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
-    }catch(IndexOutOfBoundsException e){
+    } catch (IndexOutOfBoundsException e) {
       responseMap.put("result", "matchmaking_full");
-      responseMap.put(
-          "details", "Courts are currently full: " + e.getMessage());
+      responseMap.put("details", "Courts are currently full: " + e.getMessage());
       responseMap.put("queries", request.queryParams());
       return adapter.toJson(responseMap);
     }

--- a/backend/src/main/java/server/handlers/queue/QueueViewHandler.java
+++ b/backend/src/main/java/server/handlers/queue/QueueViewHandler.java
@@ -8,7 +8,6 @@ import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
 import server.Server;
-import server.exceptions.NoItemFoundException;
 import spark.Request;
 import spark.Response;
 import spark.Route;
@@ -36,22 +35,22 @@ public class QueueViewHandler implements Route {
     HashMap<String, Object> responseMap = new HashMap<>();
 
     String playerID;
-    try{
+    try {
       Player[] queuePlayers = server.getDataStore().getQueue().toArray(new Player[0]);
-      if(request.queryMap().hasKey("id")) {
+      if (request.queryMap().hasKey("id")) {
         playerID = request.queryMap().get("id").value();
         // Get an array representation of the queue
 
         int queuePosition = -1;
         for (Player i : queuePlayers) {
-          if(playerID != i.getId()){
+          if (playerID != i.getId()) {
             queuePosition++;
-          }else{
+          } else {
             break;
           }
         }
-        responseMap.put("playerPosition",queuePosition);
-      }else{
+        responseMap.put("playerPosition", queuePosition);
+      } else {
         responseMap.put("PlayerQueue", queuePlayers);
       }
     } catch (Exception e) {
@@ -67,5 +66,4 @@ public class QueueViewHandler implements Route {
     System.out.println(server.getDataStore().getQueue());
     return adapter.toJson(responseMap);
   }
-
 }

--- a/backend/src/test/java/MatchMakingTests/PositionMatchTest.java
+++ b/backend/src/test/java/MatchMakingTests/PositionMatchTest.java
@@ -8,7 +8,6 @@ import Matchmaking.Team;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -17,20 +16,23 @@ import org.testng.Assert;
 
 public class PositionMatchTest {
   private PositionMatchMaker pmm;
+
   public List<Player> makePlayers(int playerCount) {
     List<Player> players = new ArrayList<>();
     Position[] positions = Position.values();
-    for (int i = 0; i < playerCount; i ++) {
+    for (int i = 0; i < playerCount; i++) {
       Position position = positions[i % 5];
       Player player = new Player(Integer.toString(i), position);
       players.add(player);
     }
     return players;
   }
+
   @BeforeEach
   public void setup() {
     this.pmm = new PositionMatchMaker();
   }
+
   @Test
   public void positionSimpleTest() throws IOException {
     List<Player> players = makePlayers(10);
@@ -41,15 +43,16 @@ public class PositionMatchTest {
     Team team2 = match.getTeam2();
     List<Position> position1 = new ArrayList<>(Arrays.asList(Position.values()));
     List<Position> position2 = new ArrayList<>(Arrays.asList(Position.values()));
-    for(Player player: team1.getPlayers()) {
+    for (Player player : team1.getPlayers()) {
       position1.remove(player.getPosition());
     }
-    for(Player player : team2.getPlayers()) {
+    for (Player player : team2.getPlayers()) {
       position2.remove(player.getPosition());
     }
     Assert.assertTrue(position1.isEmpty());
     Assert.assertTrue(position2.isEmpty());
   }
+
   @Test
   public void position4team() throws IOException {
     List<Player> players = makePlayers(20);
@@ -66,16 +69,16 @@ public class PositionMatchTest {
     List<Position> position3 = new ArrayList<>(Arrays.asList(Position.values()));
     List<Position> position4 = new ArrayList<>(Arrays.asList(Position.values()));
 
-    for(Player player: team1.getPlayers()) {
+    for (Player player : team1.getPlayers()) {
       position1.remove(player.getPosition());
     }
-    for(Player player : team2.getPlayers()) {
+    for (Player player : team2.getPlayers()) {
       position2.remove(player.getPosition());
     }
-    for(Player player : team3.getPlayers()) {
+    for (Player player : team3.getPlayers()) {
       position3.remove(player.getPosition());
     }
-    for(Player player : team4.getPlayers()) {
+    for (Player player : team4.getPlayers()) {
       position4.remove(player.getPosition());
     }
     Assert.assertTrue(position1.isEmpty());

--- a/backend/src/test/java/MatchMakingTests/SimpleMatchTests.java
+++ b/backend/src/test/java/MatchMakingTests/SimpleMatchTests.java
@@ -8,25 +8,26 @@ import Matchmaking.Team;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.testng.Assert;
 
 public class SimpleMatchTests {
   private SimpleMatchMaker smm;
+
   public List<Player> makePlayers(int playerCount) {
     List<Player> players = new ArrayList<>();
     Position[] positions = Position.values();
-    for (int i = 0; i < playerCount; i ++) {
+    for (int i = 0; i < playerCount; i++) {
       Position position = positions[i % 5];
       Player player = new Player(Integer.toString(i), position);
       players.add(player);
     }
     return players;
   }
+
   @Test
-  public void testMakePlayers(){
+  public void testMakePlayers() {
     List<Player> players = makePlayers(10);
     Position[] positions = Position.values();
     for (int i = 0; i < players.size(); i++) {
@@ -35,10 +36,12 @@ public class SimpleMatchTests {
       System.out.println(players.get(i).getPosition());
     }
   }
+
   @BeforeEach
   public void setup() {
     this.smm = new SimpleMatchMaker();
   }
+
   @Test
   public void testSimpleMatch() throws IOException {
     List<Player> tenPLayers = this.makePlayers(10);
@@ -50,17 +53,18 @@ public class SimpleMatchTests {
     Assert.assertEquals(team1.getSize(), 5);
     Assert.assertEquals(team2.getSize(), 5);
   }
+
   @Test
   public void unevenTeams() throws IOException {
     List<Player> tenPlayers = this.makePlayers(10);
     try {
       List<Match> matches = this.smm.matchmaker(tenPlayers, 3);
-    }
-    catch (IOException e){
+    } catch (IOException e) {
       return;
     }
     throw new AssertionError("Error Not Thrown");
   }
+
   @Test
   public void multiTeams() throws IOException {
     List<Player> twentyPLayers = this.makePlayers(20);

--- a/backend/src/test/java/SkillCalculatorTests/EloSkillTest.java
+++ b/backend/src/test/java/SkillCalculatorTests/EloSkillTest.java
@@ -6,7 +6,6 @@ import Matchmaking.Outcome;
 import Matchmaking.Player;
 import Matchmaking.Position;
 import Matchmaking.SkillCalculators.EloSkill;
-import Matchmaking.SkillCalculators.WLSkill;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -16,20 +15,23 @@ import org.testng.Assert;
 
 public class EloSkillTest {
   EloSkill eloSkill;
+
   public List<Player> makePlayers(int playerCount) {
     List<Player> players = new ArrayList<>();
     Position[] positions = Position.values();
-    for (int i = 0; i < playerCount; i ++) {
+    for (int i = 0; i < playerCount; i++) {
       Position position = positions[i % 5];
       Player player = new Player(Integer.toString(i), position);
       players.add(player);
     }
     return players;
   }
+
   @BeforeEach
-  public void setup(){
+  public void setup() {
     eloSkill = new EloSkill();
   }
+
   @Test
   public void simpleEloTest() throws IOException {
     List<Player> players = makePlayers(2);
@@ -41,6 +43,5 @@ public class EloSkillTest {
     this.eloSkill.skillUpdater(match);
     Assert.assertEquals(players.get(0).getSkillLevel(), 1207.2, 0.1);
     Assert.assertEquals(players.get(1).getSkillLevel(), 992.8, 0.1);
-
   }
 }

--- a/backend/src/test/java/SkillCalculatorTests/WLSkillTests.java
+++ b/backend/src/test/java/SkillCalculatorTests/WLSkillTests.java
@@ -15,20 +15,23 @@ import org.testng.Assert;
 
 public class WLSkillTests {
   WLSkill wlSkill;
+
   public List<Player> makePlayers(int playerCount) {
     List<Player> players = new ArrayList<>();
     Position[] positions = Position.values();
-    for (int i = 0; i < playerCount; i ++) {
+    for (int i = 0; i < playerCount; i++) {
       Position position = positions[i % 5];
       Player player = new Player(Integer.toString(i), position);
       players.add(player);
     }
     return players;
   }
+
   @BeforeEach
-  public void setup(){
+  public void setup() {
     wlSkill = new WLSkill();
   }
+
   @Test
   public void simpleWlSkill() throws IOException {
     List<Player> players = makePlayers(10);
@@ -44,9 +47,11 @@ public class WLSkillTests {
       Assert.assertEquals(player.getSkillLevel(), 0);
     }
   }
-  @Test void complicatedWlSkill() throws IOException {
+
+  @Test
+  void complicatedWlSkill() throws IOException {
     List<Player> players = makePlayers(10);
-    for(int i = 0; i < 10; i++) {
+    for (int i = 0; i < 10; i++) {
       if (i % 2 == 0) {
         players.get(i).addWin();
       } else {
@@ -63,6 +68,5 @@ public class WLSkillTests {
     for (Player player : match.getTeam1().getPlayers()) {
       Assert.assertEquals(player.getSkillLevel(), 0.5);
     }
-
   }
 }

--- a/backend/src/test/java/serverTests/matchTests/MatchAddTest.java
+++ b/backend/src/test/java/serverTests/matchTests/MatchAddTest.java
@@ -2,9 +2,13 @@ package serverTests.matchTests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import Matchmaking.CourtAssigners.CourtAssigner;
+import Matchmaking.MatchAlgs.SimpleMatchMaker;
+import Matchmaking.SkillCalculators.SimpleSkill;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import datastorage.SimpleDataStore;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -36,7 +40,9 @@ public class MatchAddTest {
   @BeforeEach
   public void setup() throws FileNotFoundException {
 
-    Server server = new Server();
+    Server server =
+        new Server(
+            new SimpleDataStore(), new CourtAssigner(6, new SimpleMatchMaker(), new SimpleSkill()));
 
     Spark.init();
     Spark.awaitInitialization();

--- a/backend/src/test/java/serverTests/matchTests/MatchViewTest.java
+++ b/backend/src/test/java/serverTests/matchTests/MatchViewTest.java
@@ -2,9 +2,13 @@ package serverTests.matchTests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import Matchmaking.CourtAssigners.CourtAssigner;
+import Matchmaking.MatchAlgs.SimpleMatchMaker;
+import Matchmaking.SkillCalculators.SimpleSkill;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import datastorage.SimpleDataStore;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -36,7 +40,9 @@ public class MatchViewTest {
   @BeforeEach
   public void setup() throws FileNotFoundException {
 
-    Server server = new Server();
+    Server server =
+        new Server(
+            new SimpleDataStore(), new CourtAssigner(6, new SimpleMatchMaker(), new SimpleSkill()));
 
     Spark.init();
     Spark.awaitInitialization();

--- a/backend/src/test/java/serverTests/profileTests/ProfileEditTest.java
+++ b/backend/src/test/java/serverTests/profileTests/ProfileEditTest.java
@@ -2,9 +2,13 @@ package serverTests.profileTests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import Matchmaking.CourtAssigners.CourtAssigner;
+import Matchmaking.MatchAlgs.SimpleMatchMaker;
+import Matchmaking.SkillCalculators.SimpleSkill;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import datastorage.SimpleDataStore;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -36,7 +40,9 @@ public class ProfileEditTest {
   @BeforeEach
   public void setup() throws FileNotFoundException {
 
-    Server server = new Server();
+    Server server =
+        new Server(
+            new SimpleDataStore(), new CourtAssigner(6, new SimpleMatchMaker(), new SimpleSkill()));
 
     Spark.init();
     Spark.awaitInitialization();

--- a/backend/src/test/java/serverTests/profileTests/ProfileViewTest.java
+++ b/backend/src/test/java/serverTests/profileTests/ProfileViewTest.java
@@ -2,11 +2,15 @@ package serverTests.profileTests;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import Matchmaking.CourtAssigners.CourtAssigner;
+import Matchmaking.MatchAlgs.SimpleMatchMaker;
 import Matchmaking.Player;
 import Matchmaking.Position;
+import Matchmaking.SkillCalculators.SimpleSkill;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
+import datastorage.SimpleDataStore;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -43,7 +47,9 @@ public class ProfileViewTest {
   @BeforeEach
   public void setup() throws FileNotFoundException {
 
-    server = new Server();
+    server =
+        new Server(
+            new SimpleDataStore(), new CourtAssigner(6, new SimpleMatchMaker(), new SimpleSkill()));
 
     Spark.init();
     Spark.awaitInitialization();
@@ -73,6 +79,7 @@ public class ProfileViewTest {
   /**
    * Checks that any items within the database that can be recalled via a get query to the database
    * can be retrieved via a view query to the API.
+   *
    * @throws ItemAlreadyExistsException
    * @throws IOException
    */


### PR DESCRIPTION
Added a match end handler for the server.  It requires all players ids to be accounted for, then it automatically removes the match, sets the variables as appropriate, and updates the player skill. I think that the only large problem with this (besides potentially unaccounted-for bugs) is that it isn't resilient against someone deleting their account in the midst of a match. I may account for this in a patch to the profile-edit handler in future.