### PR TITLE
Improved legibility of server README

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,58 @@ Currently, you will have to start the backend server by running the main program
      
 ### Example Queries
 
+For the sake of brevity, some example queries will have the following two aliases instead of the entire object. This is because these objects are either very large, repititious, or both; and, therefore need to be aliased under a smaller name. They are the following:
+
+
+Note: Each `matchN` here represents the following structure: {"result":"success","matches":[{"outcome":"ONGOING","team1":{"avgSkill":10.0,"players":[{player1},{player2},{player3},{player4},{player5}],"size":5},"team2":{"avgSkill":10.0,"players":[{player6},{player7},{player8},{player9},{player10}],"size":5}},null,null,null,null,null],"queries":[]}. Each `playerN` value represents the following:  `{"id":"1234567890","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0}`
+
+
+1. `playerN`
+
+```
+    {
+        "id":{ID},
+        "losses":{Losses},
+        "name":{name},
+        "position":{Position},
+        "skillLevel":{Skill Level},
+        "wins":{Wins}
+    }
+```
+
+2. `matchN`
+
+```
+{
+    "outcome":"ONGOING",
+    "team1":
+        {
+            "avgSkill":10.0,
+            "players":
+                [
+                    {player1},
+                    {player2},
+                    {player3},
+                    {player4},
+                    {player5}
+                ],
+            "size":5
+        },
+    "team2":
+        {
+            "avgSkill":10.0,
+            "players":
+                [
+                    {player6},
+                    {player7},
+                    {player8},
+                    {player9},
+                    {player10}
+                ],
+        "size":5
+    }
+```
+
 #### `profile-add <name> <position> <id>`
 1. profile-add?name=Josh Joshington&position=SMALL_FORWARD&id=a0Xd2wuFh9oGb3aJuv4K
 
@@ -189,6 +241,7 @@ failure condition. the result is `error_bad_request` and the corresponding excep
 
 #### `match-add <id>`
 
+
 1. match-add?id=a0Xd2wuFh9oGb3aJuv4K
 
 ```
@@ -201,12 +254,48 @@ failure condition. the result is `error_bad_request` and the corresponding excep
 ```
 
 #### `match-view`
-   2. Example Queries (for a matchmaker with a limit of 3 matches). Each `matchN` here represents the following structure: {"result":"success","matches":[{"outcome":"ONGOING","team1":{"avgSkill":10.0,"players":[{player1},{player2},{player3},{player4},{player5}],"size":5},"team2":{"avgSkill":10.0,"players":[{player6},{player7},{player8},{player9},{player10}],"size":5}},null,null,null,null,null],"queries":[]}. Each `playerN` value represents the following:  `{"id":"1234567890","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0}`
-      1. match-view --> {"result":"success","matches":[{match1},{match2},{match3}],"queries":[]}
+1. match-view (Shown here with 3 matches but this number is configurable)
+
+```
+    {
+        "result":"success",
+        "matches":
+            [
+                {match1},
+                {match2},
+                {match3}
+            ],
+        "queries":[]
+    }
+```
+
 #### `queue-view`
-   2. Example Queries:
-      1. queue-view --> {"result":"success","PlayerQueue":[{"id":"a0Xd2wuFh9oGb3aJuv4K","losses":12,"name":"Josh Joshington","position":"POWER_FORWARD","skillLevel":10.0,"wins":20}],"queries":[]}
-      2. queue-view --> {"result":"success","playerPosition":1,"queries":["id"]}
+1. queue-view
+```
+    {
+        "result":"success",
+        "PlayerQueue":
+            [
+                {
+                    "id":"a0Xd2wuFh9oGb3aJuv4K",
+                    "losses":12,
+                    "name":"Josh Joshington",
+                    "position":"POWER_FORWARD",
+                    "skillLevel":10.0,
+                    "wins":20
+                }
+            ],
+        "queries":[]
+    }
+```
+2. queue-view?id=a0Xd2wuFh9oGb3aJuv4K
+```
+    {
+        "result":"success",
+        "playerPosition":1,
+        "queries":["id"]
+    }
+```
 #### `queue-add <id>`
    3. Example Queries:
       1. queue-add?id=1234567890 --> {"result":"success","Message":"Player added to queue","newCourtMade":false,"addedID":"1234567890"} 

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ failure condition. the result is `error_bad_request` and the corresponding excep
     {
         "result":"success",
         "matchAdded":
-            {Note: this is a very large object and I am not entirely sure yet what of it I should realistically send to the frontend, as of such I am holding off on setting in stone what is returned here},
+            {match1},
         "queries":["id"]
     }
 ```
@@ -297,12 +297,60 @@ failure condition. the result is `error_bad_request` and the corresponding excep
     }
 ```
 #### `queue-add <id>`
-   3. Example Queries:
-      1. queue-add?id=1234567890 --> {"result":"success","Message":"Player added to queue","newCourtMade":false,"addedID":"1234567890"} 
-      2. queue-add?id=1234567890 (second time) --> "result":"error_bad_request","details":"Player has already been added to queue.","newCourtMade":false,"queries":["id"]}
-      3. queue-add?id=incorrectID --> {"result":"error_bad_request","details":"Player Not Found: No Player found with corresponding ID","newCourtMade":false,"queries":["id"]}
-   4. Example Query For Successful Match Creation. Every `{playerN}` here represents a different player (including the one just added) such as this: `{"id":"1234567890","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0}`
-      5. queue-add?id=1 --> {"result":"success","Message":"Player added to queue","newCourtMade":true,"addedID":"1","court":{"match":{"outcome":"ONGOING","team1":{"avgSkill":10.0,"players":[{player1},{player2},{player3},{player4},{player5}],"size":5},"team2":{"avgSkill":10.0,"players":[{player6},{player7},{player8},{player9},{player10}],"size":5}},"players":[{player1},{player2},{player3},{player4},{player5},{player6},{player7},{player8},{player9},{player10}]}}
+
+1. queue-add?id=1234567890
+```
+    {
+        "result":"success",
+        "Message":"Player added to queue",
+        "newCourtMade":false,
+        "addedID":"1234567890"
+    }
+```
+2. queue-add?id=1234567890 (second time)
+```
+    {
+        "result":"error_bad_request",
+        "details":"Player has already been added to queue.",
+        "newCourtMade":false,
+        "queries":["id"]
+    }
+```
+3. queue-add?id=incorrectID
+```
+    {
+        "result":"error_bad_request",
+        "details":"Player Not Found: No Player found with corresponding ID",
+        "newCourtMade":false,
+        "queries":["id"]
+    }
+```
+5. queue-add?id=1
+```
+    {
+        "result":"success",
+        "Message":"Player added to queue",
+        "newCourtMade":true,
+        "addedID":"1",
+        "court":
+            {
+                "match":{match1},
+                "players":
+                    [
+                        {player1},
+                        {player2},
+                        {player3},
+                        {player4},
+                        {player5},
+                        {player6},
+                        {player7},
+                        {player8},
+                        {player9},
+                        {player10}
+                    ]
+            }
+    }
+```
    5. Additionally, there exist the following errors:
        1. `matchmaking_error` --> There has been an internal matchmaker error. If the matchmaker is properly tested, this will not come up.
        2. `matchmaking_full` --> Every alotted court has been filled up, the player has successfully been added to the queue, but they need to wait until other people leave to free them a space.

--- a/README.md
+++ b/README.md
@@ -46,6 +46,19 @@ Currently, you will have to start the backend server by running the main program
    1. Adds a player to the matchmaking queue. When the queue length is 10, the first 10 players in the queue will be dequeued into a match. Whether this has happened will be represented by the NewCourtAdded boolean, which will be true if a new court has been added, and false otherwise.
    2. The `id` keyword is a randomized, unique ID for each player. 20 characters long.
      
+### Results
+
+There are 6 various response and error codes from the backend API.
+
+| Result | Meaning |
+| ------ | ------- |
+| `success` | The operation was parsed correctly and there were no issues, internal or external, with your request. |
+| `error_bad_request` | The most common error. This is thrown when a query is missing or when the contents of the query do not meet the specificationg of the API. More information is shown in the `details` portion of the response. |
+| `error_server` | There has been an internal server error while processing your request. Possible diagnostics include sending the request again or sending angry messages to the developers, which is the less preferred option. |
+| `error_datastore` | There was a failure in the datastore portion of the server. The recommended course of action here is to check over your datastore object and test its functionality. |
+| `matchmaking_error` | There has been an internal matchmaker error. Additional testing and review of matchmakers will allay this error. |
+| `matchmaking_full` | Every alotted court has been filled up, the player has successfully been added to the queue, but they need to wait until other people leave to free them a space. |
+
 ### Example Queries
 
 For the sake of brevity, some example queries will have the following two aliases instead of the entire object. This is because these objects are either very large, repititious, or both; and, therefore need to be aliased under a smaller name. They are the following:
@@ -240,6 +253,12 @@ For the sake of brevity, some example queries will have the following two aliase
     }
 ```
 
+</details>
+
+<details>
+    <summary>Unsuccessful requests</summary>
+    <br>
+
 5. profile-edit?action=edit&id=definitelynotaplayerid&name=Bames Jond&position=SHOOTING_GUARD
 
 ```
@@ -272,6 +291,7 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "queries":["id"]
     }
 ```
+
 </details>
 
 #### `match-view`
@@ -346,29 +366,7 @@ failure condition. the result is `error_bad_request` and the corresponding excep
     }
 ```
 
-2. queue-add?id=1234567890 (second time)
-
-```
-    {
-        "result":"error_bad_request",
-        "details":"Player has already been added to queue.",
-        "newCourtMade":false,
-        "queries":["id"]
-    }
-```
-
-3. queue-add?id=incorrectID
-
-```
-    {
-        "result":"error_bad_request",
-        "details":"Player Not Found: No Player found with corresponding ID",
-        "newCourtMade":false,
-        "queries":["id"]
-    }
-```
-
-5. queue-add?id=1
+2. queue-add?id=1
 
 ```
     {
@@ -397,9 +395,33 @@ failure condition. the result is `error_bad_request` and the corresponding excep
 ```
 </details>
 
-   5. Additionally, there exist the following errors:
-       1. `matchmaking_error` --> There has been an internal matchmaker error. If the matchmaker is properly tested, this will not come up.
-       2. `matchmaking_full` --> Every alotted court has been filled up, the player has successfully been added to the queue, but they need to wait until other people leave to free them a space.
+<details>
+    <summary>Unsuccessful requests</summary>
+    <br>
+
+2. queue-add?id=1234567890 (second time)
+
+```
+    {
+        "result":"error_bad_request",
+        "details":"Player has already been added to queue.",
+        "newCourtMade":false,
+        "queries":["id"]
+    }
+```
+
+3. queue-add?id=incorrectID
+
+```
+    {
+        "result":"error_bad_request",
+        "details":"Player Not Found: No Player found with corresponding ID",
+        "newCourtMade":false,
+        "queries":["id"]
+    }
+```
+
+</details>
 
 ## Backend Player, Team, and Matches
 Each user in omatch will be assigned a Player class. This class will contain their specific user ID, skill level, W/L record, position, and other necessary information. 

--- a/README.md
+++ b/README.md
@@ -48,40 +48,172 @@ Currently, you will have to start the backend server by running the main program
      
 ### Example Queries
 
-1. `profile-add <name> <position>`
-    5. Example Queries:
-          1. `profile-add?name=Josh Joshington&position=SMALL_FORWARD` --> {"result":"success","playerID":"a0Xd2wuFh9oGb3aJuv4K","queries":["name","position"]}
-          2. `profile-add?name=Baka Sussy&position=CENTER` --> {"result":"success","playerID":"awWo0cH6jw4Ib8fD9Fgi","queries":["name","position"]}
-2. `profile-view <id>`
-   3. Example Queries:
-        1. `profile-view?id=a0Xd2wuFh9oGb3aJuv4K` --> {"result":"success","player":{"id":"a0Xd2wuFh9oGb3aJuv4K","name":"Josh Joshington","skillLevel":9001.112,"wins":12,"losses":0,"Position":"SMALL_FORWARD"},"queries":["id"]}
-        2. `profile-view?id=awWo0cH6jw4Ib8fD9Fgi` --> {"result":"success","player":{"id":"awWo0cH6jw4Ib8fD9Fgi","name":"Baka Sussy","skillLevel":235,"wins":6,"losses":29,"Position":"CENTER"},"queries":["id"]}
-        3. `profile-view` --> {"result":"success","players":{"a0Xd2wuFh9oGb3aJuv4K":{"id":"a0Xd2wuFh9oGb3aJuv4K","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0},"awWo0cH6jw4Ib8fD9Fgi":{"id":"awWo0cH6jw4Ib8fD9Fgi","losses":0,"name":Baka Sussy","position":"CENTER","skillLevel":10.0,"wins":0}},"queries":[]}
-3. `profile-edit <action> <id> (name) (position)`
-   6. Example Queries:
-      1. `profile-edit?action=delete&id=a0Xd2wuFh9oGb3aJuv4K` --> {"result":"success","queries":["action","id"]}
-      2. `profile-edit?action=eDiT&id=awWo0cH6jw4Ib8fD9Fgi&name=Sussy Baka&position=SHOOTING_GUARD` --> {"result":"success","queries":["action","id","name","position"]}
-      3. `profile-edit?action=EDIT&id=awWo0cH6jw4Ib8fD9Fgi&position=SHOOTING_GUARD` --> {"result":"success","queries":["action","id","position"]}
-      4. `profile-edit?action=edit&id=a0Xd2wuFh9oGb3aJuv4K&name=Bosh Boshington` --> {"result":"success","queries":["action","id",'name"]}
-      5. `profile-edit?action=edit&id=definitelynotaplayerid&name=Bames Jond&position=SHOOTING_GUARD` --> failure condition. the result is `error_bad_request` and the corresponding exception sent back is a `NoItemFoundException`
-      6. `profile-edit?id=definitelynotaplayerid&name=Jond, Bames Jond&position=SHOOTING_GUARD` --> {"result":"error_bad_request","details":"action keyword must contain the word 'edit' or 'delete'. Any other word will result in an error","queries":["id","name","position"]}
-4. `match-add <id>`
-   3. Example Queries:
-      1. `match-add?id=a0Xd2wuFh9oGb3aJuv4K` --> {"result":"success","matchAdded":{Note: this is a very large object and I am not entirely sure yet what of it I should realistically send to the frontend, as of such I am holding off on setting in stone what is returned here},"queries":["id"]}
-5. `match-view`
+#### `profile-add <name> <position> <id>`
+1. profile-add?name=Josh Joshington&position=SMALL_FORWARD&id=a0Xd2wuFh9oGb3aJuv4K
+
+
+```
+    {
+        "result":"success",
+        "playerID":"a0Xd2wuFh9oGb3aJuv4K",
+        "queries":
+            ["name","position"]
+    }
+```
+
+2. profile-add?name=Baka Sussy&position=CENTER&id=awWo0cH6jw4Ib8fD9Fgi
+
+```
+    {
+        "result":"success",
+        "playerID":"awWo0cH6jw4Ib8fD9Fgi",
+        "queries":
+            ["name","position"]
+    }
+```
+#### `profile-view <id>`
+
+1. profile-view?id=a0Xd2wuFh9oGb3aJuv4K
+
+```
+    {
+        "result":"success",
+        "player":
+            {
+                "id":"a0Xd2wuFh9oGb3aJuv4K",
+                "name":"Josh Joshington",
+                "skillLevel":9001.112,
+                "wins":12,
+                "losses":0,
+                "Position":"SMALL_FORWARD"
+            },
+        "queries":
+            ["id"]
+    }
+```
+
+2. profile-view?id=awWo0cH6jw4Ib8fD9Fgi
+
+```
+    {
+        "result":"success",
+        "player":
+            {
+                "id":"awWo0cH6jw4Ib8fD9Fgi",
+                "name":"Baka Sussy",
+                "skillLevel":235,
+                "wins":6,
+                "losses":29,
+                "Position":"CENTER"
+            },
+        "queries": ["id"]
+    }
+```
+
+3. profile-view
+
+```
+    {
+        "result":"success",
+        "players":
+            {
+                "a0Xd2wuFh9oGb3aJuv4K":
+                    {
+                        "id":"a0Xd2wuFh9oGb3aJuv4K",
+                        "losses":0,
+                        "name":"Josh Joshington",
+                        "position":"SMALL_FORWARD",
+                        "skillLevel":10.0,
+                        "wins":0},
+                "awWo0cH6jw4Ib8fD9Fgi":
+                    {
+                        "id":"awWo0cH6jw4Ib8fD9Fgi",
+                        "losses":0,
+                        "name":Baka Sussy",
+                        "position":"CENTER",
+                        "skillLevel":10.0,"wins":0
+                    }
+            },
+        "queries":[]
+    }
+```
+
+#### `profile-edit <action> <id> (name) (position)`
+1. profile-edit?action=delete&id=a0Xd2wuFh9oGb3aJuv4K
+```
+    {
+        "result":"success",
+        "queries":
+            ["action","id"]
+    }
+```
+
+2. profile-edit?action=eDiT&id=awWo0cH6jw4Ib8fD9Fgi&name=Sussy Baka&position=SHOOTING_GUARD
+```
+    {
+        "result":"success",
+        "queries":
+            ["action","id","name","position"]
+    }
+```
+
+3. profile-edit?action=EDIT&id=awWo0cH6jw4Ib8fD9Fgi&position=SHOOTING_GUARD
+```
+    {
+        "result":"success",
+        "queries":["action","id","position"]
+    }
+```
+
+4. profile-edit?action=edit&id=a0Xd2wuFh9oGb3aJuv4K&name=Bosh Boshington
+```
+    {
+        "result":"success",
+        "queries":["action","id",'name"]
+    }
+```
+
+5. profile-edit?action=edit&id=definitelynotaplayerid&name=Bames Jond&position=SHOOTING_GUARD
+```
+failure condition. the result is `error_bad_request` and the corresponding exception sent back is a `NoItemFoundException`
+```
+
+6. profile-edit?id=definitelynotaplayerid&name=Jond, Bames Jond&position=SHOOTING_GUARD
+```
+    {
+        "result":"error_bad_request",
+        "details":"action keyword must contain the word 'edit' or 'delete'. Any other word will result in an error",
+        "queries":["id","name","position"]
+    }
+```
+
+#### `match-add <id>`
+
+1. match-add?id=a0Xd2wuFh9oGb3aJuv4K
+
+```
+    {
+        "result":"success",
+        "matchAdded":
+            {Note: this is a very large object and I am not entirely sure yet what of it I should realistically send to the frontend, as of such I am holding off on setting in stone what is returned here},
+        "queries":["id"]
+    }
+```
+
+#### `match-view`
    2. Example Queries (for a matchmaker with a limit of 3 matches). Each `matchN` here represents the following structure: {"result":"success","matches":[{"outcome":"ONGOING","team1":{"avgSkill":10.0,"players":[{player1},{player2},{player3},{player4},{player5}],"size":5},"team2":{"avgSkill":10.0,"players":[{player6},{player7},{player8},{player9},{player10}],"size":5}},null,null,null,null,null],"queries":[]}. Each `playerN` value represents the following:  `{"id":"1234567890","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0}`
-      1. `match-view` --> {"result":"success","matches":[{match1},{match2},{match3}],"queries":[]}
-5. `queue-view`
+      1. match-view --> {"result":"success","matches":[{match1},{match2},{match3}],"queries":[]}
+#### `queue-view`
    2. Example Queries:
-      1. `queue-view` --> {"result":"success","PlayerQueue":[{"id":"a0Xd2wuFh9oGb3aJuv4K","losses":12,"name":"Josh Joshington","position":"POWER_FORWARD","skillLevel":10.0,"wins":20}],"queries":[]}
-      2. `queue-view` --> {"result":"success","playerPosition":1,"queries":["id"]}
-6. `queue-add <id>`
+      1. queue-view --> {"result":"success","PlayerQueue":[{"id":"a0Xd2wuFh9oGb3aJuv4K","losses":12,"name":"Josh Joshington","position":"POWER_FORWARD","skillLevel":10.0,"wins":20}],"queries":[]}
+      2. queue-view --> {"result":"success","playerPosition":1,"queries":["id"]}
+#### `queue-add <id>`
    3. Example Queries:
-      1. `queue-add?id=1234567890` --> {"result":"success","Message":"Player added to queue","newCourtMade":false,"addedID":"1234567890"} 
-      2. `queue-add?id=1234567890 (second time)` --> "result":"error_bad_request","details":"Player has already been added to queue.","newCourtMade":false,"queries":["id"]}
-      3. `queue-add?id=incorrectID` --> {"result":"error_bad_request","details":"Player Not Found: No Player found with corresponding ID","newCourtMade":false,"queries":["id"]}
+      1. queue-add?id=1234567890 --> {"result":"success","Message":"Player added to queue","newCourtMade":false,"addedID":"1234567890"} 
+      2. queue-add?id=1234567890 (second time) --> "result":"error_bad_request","details":"Player has already been added to queue.","newCourtMade":false,"queries":["id"]}
+      3. queue-add?id=incorrectID --> {"result":"error_bad_request","details":"Player Not Found: No Player found with corresponding ID","newCourtMade":false,"queries":["id"]}
    4. Example Query For Successful Match Creation. Every `{playerN}` here represents a different player (including the one just added) such as this: `{"id":"1234567890","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0}`
-      5. `queue-add?id=1` --> {"result":"success","Message":"Player added to queue","newCourtMade":true,"addedID":"1","court":{"match":{"outcome":"ONGOING","team1":{"avgSkill":10.0,"players":[{player1},{player2},{player3},{player4},{player5}],"size":5},"team2":{"avgSkill":10.0,"players":[{player6},{player7},{player8},{player9},{player10}],"size":5}},"players":[{player1},{player2},{player3},{player4},{player5},{player6},{player7},{player8},{player9},{player10}]}}
+      5. queue-add?id=1 --> {"result":"success","Message":"Player added to queue","newCourtMade":true,"addedID":"1","court":{"match":{"outcome":"ONGOING","team1":{"avgSkill":10.0,"players":[{player1},{player2},{player3},{player4},{player5}],"size":5},"team2":{"avgSkill":10.0,"players":[{player6},{player7},{player8},{player9},{player10}],"size":5}},"players":[{player1},{player2},{player3},{player4},{player5},{player6},{player7},{player8},{player9},{player10}]}}
    5. Additionally, there exist the following errors:
        1. `matchmaking_error` --> There has been an internal matchmaker error. If the matchmaker is properly tested, this will not come up.
        2. `matchmaking_full` --> Every alotted court has been filled up, the player has successfully been added to the queue, but they need to wait until other people leave to free them a space.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,10 @@ Note: Each `matchN` here represents the following structure: {"result":"success"
 ```
 
 #### `profile-add <name> <position> <id>`
+
+<details>
+    <summary>Successful requests</summary>
+    <br>
 1. profile-add?name=Josh Joshington&position=SMALL_FORWARD&id=a0Xd2wuFh9oGb3aJuv4K
 
 
@@ -123,8 +127,13 @@ Note: Each `matchN` here represents the following structure: {"result":"success"
             ["name","position"]
     }
 ```
+</details>
+
 #### `profile-view <id>`
 
+<details>
+    <summary>Successful requests</summary>
+    <br>
 1. profile-view?id=a0Xd2wuFh9oGb3aJuv4K
 
 ```
@@ -189,9 +198,15 @@ Note: Each `matchN` here represents the following structure: {"result":"success"
         "queries":[]
     }
 ```
+</details>
 
 #### `profile-edit <action> <id> (name) (position)`
+
+<details>
+    <summary>Successful requests</summary>
+    <br>
 1. profile-edit?action=delete&id=a0Xd2wuFh9oGb3aJuv4K
+
 ```
     {
         "result":"success",
@@ -201,6 +216,7 @@ Note: Each `matchN` here represents the following structure: {"result":"success"
 ```
 
 2. profile-edit?action=eDiT&id=awWo0cH6jw4Ib8fD9Fgi&name=Sussy Baka&position=SHOOTING_GUARD
+
 ```
     {
         "result":"success",
@@ -210,6 +226,7 @@ Note: Each `matchN` here represents the following structure: {"result":"success"
 ```
 
 3. profile-edit?action=EDIT&id=awWo0cH6jw4Ib8fD9Fgi&position=SHOOTING_GUARD
+
 ```
     {
         "result":"success",
@@ -218,6 +235,7 @@ Note: Each `matchN` here represents the following structure: {"result":"success"
 ```
 
 4. profile-edit?action=edit&id=a0Xd2wuFh9oGb3aJuv4K&name=Bosh Boshington
+
 ```
     {
         "result":"success",
@@ -226,11 +244,13 @@ Note: Each `matchN` here represents the following structure: {"result":"success"
 ```
 
 5. profile-edit?action=edit&id=definitelynotaplayerid&name=Bames Jond&position=SHOOTING_GUARD
+
 ```
 failure condition. the result is `error_bad_request` and the corresponding exception sent back is a `NoItemFoundException`
 ```
 
 6. profile-edit?id=definitelynotaplayerid&name=Jond, Bames Jond&position=SHOOTING_GUARD
+
 ```
     {
         "result":"error_bad_request",
@@ -238,10 +258,13 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "queries":["id","name","position"]
     }
 ```
+</details>
 
 #### `match-add <id>`
 
-
+<details>
+    <summary>Successful requests</summary>
+    <br>
 1. match-add?id=a0Xd2wuFh9oGb3aJuv4K
 
 ```
@@ -252,8 +275,13 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "queries":["id"]
     }
 ```
+</details>
 
 #### `match-view`
+
+<details>
+    <summary>Successful requests</summary>
+    <br>
 1. match-view (Shown here with 3 matches but this number is configurable)
 
 ```
@@ -268,9 +296,15 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "queries":[]
     }
 ```
+</details>
 
 #### `queue-view`
+
+<details>
+    <summary>Successful requests</summary>
+    <br>
 1. queue-view
+
 ```
     {
         "result":"success",
@@ -288,6 +322,7 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "queries":[]
     }
 ```
+    
 2. queue-view?id=a0Xd2wuFh9oGb3aJuv4K
 ```
     {
@@ -296,9 +331,15 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "queries":["id"]
     }
 ```
+</details>
+
 #### `queue-add <id>`
 
+<details>
+    <summary>Successful requests</summary>
+    <br>
 1. queue-add?id=1234567890
+
 ```
     {
         "result":"success",
@@ -307,7 +348,9 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "addedID":"1234567890"
     }
 ```
+
 2. queue-add?id=1234567890 (second time)
+
 ```
     {
         "result":"error_bad_request",
@@ -316,7 +359,9 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "queries":["id"]
     }
 ```
+
 3. queue-add?id=incorrectID
+
 ```
     {
         "result":"error_bad_request",
@@ -325,7 +370,9 @@ failure condition. the result is `error_bad_request` and the corresponding excep
         "queries":["id"]
     }
 ```
+
 5. queue-add?id=1
+
 ```
     {
         "result":"success",
@@ -351,6 +398,8 @@ failure condition. the result is `error_bad_request` and the corresponding excep
             }
     }
 ```
+</details>
+
    5. Additionally, there exist the following errors:
        1. `matchmaking_error` --> There has been an internal matchmaker error. If the matchmaker is properly tested, this will not come up.
        2. `matchmaking_full` --> Every alotted court has been filled up, the player has successfully been added to the queue, but they need to wait until other people leave to free them a space.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ Currently, you will have to start the backend server by running the main program
 
 ## Backend Handlers
 
+### Query Guide
+
 1. `profile-add <name> <position>`
     1. The profile addition handler manages the addition of profiles to the backend database. Any players with exactly the same name and position will be treated as different players with a different ID, so it is imperative that you use the editing handler for editing or deleting players.
     2. The `name` query has to do with the player's name, taken in as a UTF-8 String.
@@ -24,22 +26,38 @@ Currently, you will have to start the backend server by running the main program
           3. `SMALL_FORWARD`
           4. `POWER_FORWARD`
           5. `CENTER`
-    5. Example Queries:
-          1. `profile-add?name=Josh Joshington&position=SMALL_FORWARD` --> {"result":"success","playerID":"a0Xd2wuFh9oGb3aJuv4K","queries":["name","position"]}
-          2. `profile-add?name=Baka Sussy&position=CENTER` --> {"result":"success","playerID":"awWo0cH6jw4Ib8fD9Fgi","queries":["name","position"]}
 2. `profile-view <id>`
    1. The profile view handler retrieves all relevant data to the player, including, name, position, ELO ranking, and W/L ratio. 
    2. The `id` keyword is a randomized, unique ID for each player. 20 characters long. If no `id` keyword is present, the handler will return the list of all players
-   3. Example Queries:
-        1. `profile-view?id=a0Xd2wuFh9oGb3aJuv4K` --> {"result":"success","player":{"id":"a0Xd2wuFh9oGb3aJuv4K","name":"Josh Joshington","skillLevel":9001.112,"wins":12,"losses":0,"Position":"SMALL_FORWARD"},"queries":["id"]}
-        2. `profile-view?id=awWo0cH6jw4Ib8fD9Fgi` --> {"result":"success","player":{"id":"awWo0cH6jw4Ib8fD9Fgi","name":"Baka Sussy","skillLevel":235,"wins":6,"losses":29,"Position":"CENTER"},"queries":["id"]}
-        3. `profile-view` --> {"result":"success","players":{"a0Xd2wuFh9oGb3aJuv4K":{"id":"a0Xd2wuFh9oGb3aJuv4K","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0},"awWo0cH6jw4Ib8fD9Fgi":{"id":"awWo0cH6jw4Ib8fD9Fgi","losses":0,"name":Baka Sussy","position":"CENTER","skillLevel":10.0,"wins":0}},"queries":[]}
 3. `profile-edit <action> <id> (name) (position)`
    1. The profile edit handler manages the editing and/or deleting of players.
    2. The `action` query has to do with whether the player in question is being edited or deleted. As of such, it can be one of two strings, "edit" or "delete". These strings are not case-sensitive
    3. The `id` keyword is a randomized, unique ID for each player. 20 characters long.
    4. The `name` query is the player's new name, only recognized when the action is set to edit. This keyword is optional and the player's name will not be updated if it is not present.
    5. The `position` query is the player's updated position. These keywords are the same as for the `profile-add` handler. As with the name, this keyword is optional and will not be updated if it is not present.
+4. `match-add <id>`
+   1. The match addition handler manages player's being assigned to matches. It returns the match that the player was added to, which in turn contains all the team details.
+   2. The `id` keyword is a randomized, unique ID for each player. 20 characters long.
+5. `match-view`
+   1. Returns a list of match objects, each containing details about the court the match is taking place on, as well as teams and their respective players.
+5. `queue-view`
+   1. Returns either the queue or the position of a player within the queue
+6. `queue-add <id>`
+   1. Adds a player to the matchmaking queue. When the queue length is 10, the first 10 players in the queue will be dequeued into a match. Whether this has happened will be represented by the NewCourtAdded boolean, which will be true if a new court has been added, and false otherwise.
+   2. The `id` keyword is a randomized, unique ID for each player. 20 characters long.
+     
+### Example Queries
+
+1. `profile-add <name> <position>`
+    5. Example Queries:
+          1. `profile-add?name=Josh Joshington&position=SMALL_FORWARD` --> {"result":"success","playerID":"a0Xd2wuFh9oGb3aJuv4K","queries":["name","position"]}
+          2. `profile-add?name=Baka Sussy&position=CENTER` --> {"result":"success","playerID":"awWo0cH6jw4Ib8fD9Fgi","queries":["name","position"]}
+2. `profile-view <id>`
+   3. Example Queries:
+        1. `profile-view?id=a0Xd2wuFh9oGb3aJuv4K` --> {"result":"success","player":{"id":"a0Xd2wuFh9oGb3aJuv4K","name":"Josh Joshington","skillLevel":9001.112,"wins":12,"losses":0,"Position":"SMALL_FORWARD"},"queries":["id"]}
+        2. `profile-view?id=awWo0cH6jw4Ib8fD9Fgi` --> {"result":"success","player":{"id":"awWo0cH6jw4Ib8fD9Fgi","name":"Baka Sussy","skillLevel":235,"wins":6,"losses":29,"Position":"CENTER"},"queries":["id"]}
+        3. `profile-view` --> {"result":"success","players":{"a0Xd2wuFh9oGb3aJuv4K":{"id":"a0Xd2wuFh9oGb3aJuv4K","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0},"awWo0cH6jw4Ib8fD9Fgi":{"id":"awWo0cH6jw4Ib8fD9Fgi","losses":0,"name":Baka Sussy","position":"CENTER","skillLevel":10.0,"wins":0}},"queries":[]}
+3. `profile-edit <action> <id> (name) (position)`
    6. Example Queries:
       1. `profile-edit?action=delete&id=a0Xd2wuFh9oGb3aJuv4K` --> {"result":"success","queries":["action","id"]}
       2. `profile-edit?action=eDiT&id=awWo0cH6jw4Ib8fD9Fgi&name=Sussy Baka&position=SHOOTING_GUARD` --> {"result":"success","queries":["action","id","name","position"]}
@@ -48,22 +66,16 @@ Currently, you will have to start the backend server by running the main program
       5. `profile-edit?action=edit&id=definitelynotaplayerid&name=Bames Jond&position=SHOOTING_GUARD` --> failure condition. the result is `error_bad_request` and the corresponding exception sent back is a `NoItemFoundException`
       6. `profile-edit?id=definitelynotaplayerid&name=Jond, Bames Jond&position=SHOOTING_GUARD` --> {"result":"error_bad_request","details":"action keyword must contain the word 'edit' or 'delete'. Any other word will result in an error","queries":["id","name","position"]}
 4. `match-add <id>`
-   1. The match addition handler manages player's being assigned to matches. It returns the match that the player was added to, which in turn contains all the team details.
-   2. The `id` keyword is a randomized, unique ID for each player. 20 characters long.
    3. Example Queries:
       1. `match-add?id=a0Xd2wuFh9oGb3aJuv4K` --> {"result":"success","matchAdded":{Note: this is a very large object and I am not entirely sure yet what of it I should realistically send to the frontend, as of such I am holding off on setting in stone what is returned here},"queries":["id"]}
 5. `match-view`
-   1. Returns a list of match objects, each containing details about the court the match is taking place on, as well as teams and their respective players.
    2. Example Queries (for a matchmaker with a limit of 3 matches). Each `matchN` here represents the following structure: {"result":"success","matches":[{"outcome":"ONGOING","team1":{"avgSkill":10.0,"players":[{player1},{player2},{player3},{player4},{player5}],"size":5},"team2":{"avgSkill":10.0,"players":[{player6},{player7},{player8},{player9},{player10}],"size":5}},null,null,null,null,null],"queries":[]}. Each `playerN` value represents the following:  `{"id":"1234567890","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0}`
       1. `match-view` --> {"result":"success","matches":[{match1},{match2},{match3}],"queries":[]}
 5. `queue-view`
-   1. Returns either the queue or the position of a player within the queue
    2. Example Queries:
       1. `queue-view` --> {"result":"success","PlayerQueue":[{"id":"a0Xd2wuFh9oGb3aJuv4K","losses":12,"name":"Josh Joshington","position":"POWER_FORWARD","skillLevel":10.0,"wins":20}],"queries":[]}
       2. `queue-view` --> {"result":"success","playerPosition":1,"queries":["id"]}
 6. `queue-add <id>`
-   1. Adds a player to the matchmaking queue. When the queue length is 10, the first 10 players in the queue will be dequeued into a match. Whether this has happened will be represented by the NewCourtAdded boolean, which will be true if a new court has been added, and false otherwise.
-   2. The `id` keyword is a randomized, unique ID for each player. 20 characters long.
    3. Example Queries:
       1. `queue-add?id=1234567890` --> {"result":"success","Message":"Player added to queue","newCourtMade":false,"addedID":"1234567890"} 
       2. `queue-add?id=1234567890 (second time)` --> "result":"error_bad_request","details":"Player has already been added to queue.","newCourtMade":false,"queries":["id"]}
@@ -73,6 +85,7 @@ Currently, you will have to start the backend server by running the main program
    5. Additionally, there exist the following errors:
        1. `matchmaking_error` --> There has been an internal matchmaker error. If the matchmaker is properly tested, this will not come up.
        2. `matchmaking_full` --> Every alotted court has been filled up, the player has successfully been added to the queue, but they need to wait until other people leave to free them a space.
+
 ## Backend Player, Team, and Matches
 Each user in omatch will be assigned a Player class. This class will contain their specific user ID, skill level, W/L record, position, and other necessary information. 
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,6 @@ Currently, you will have to start the backend server by running the main program
 For the sake of brevity, some example queries will have the following two aliases instead of the entire object. This is because these objects are either very large, repititious, or both; and, therefore need to be aliased under a smaller name. They are the following:
 
 
-Note: Each `matchN` here represents the following structure: {"result":"success","matches":[{"outcome":"ONGOING","team1":{"avgSkill":10.0,"players":[{player1},{player2},{player3},{player4},{player5}],"size":5},"team2":{"avgSkill":10.0,"players":[{player6},{player7},{player8},{player9},{player10}],"size":5}},null,null,null,null,null],"queries":[]}. Each `playerN` value represents the following:  `{"id":"1234567890","losses":0,"name":"Josh Joshington","position":"SMALL_FORWARD","skillLevel":10.0,"wins":0}`
-
-
 1. `playerN`
 
 ```


### PR DESCRIPTION
I overhauled my portion of the README, adding a lot more on how to properly run the API with its queries, as well as various pitfalls that could be a problem for someone using it for the first time. I did this by documenting all potential responses in a table, moving example queries to a separate area away from the pure definitions of the handlers, adding dropdowns to not bloat the file's size upon first looking at it, and made every JSON representation more legible by indenting elements to a proper amount (I probably pressed TAB in excess of 400-700 times in the last hour. My fingers couldn't unclench for 30 minutes after lol).